### PR TITLE
fix(ci): refresh Google CLI inventory

### DIFF
--- a/crates/switchboard-providers/inventories/google.json
+++ b/crates/switchboard-providers/inventories/google.json
@@ -757,6 +757,7 @@
         "get",
         "insert",
         "patch",
+        "transferOwnership",
         "update"
       ]
     },
@@ -868,6 +869,27 @@
       "operation_kind": "write",
       "undo_support": {
         "kind": "unknown"
+      }
+    },
+    {
+      "path": [
+        "calendar",
+        "calendars",
+        "transferOwnership"
+      ],
+      "command": "gws calendar calendars transferOwnership",
+      "summary": "Transfers a secondary calendar between users within a Google Workspace organization.",
+      "usage": "gws calendars transferOwnership [OPTIONS]",
+      "help_args": [
+        "calendar",
+        "calendars",
+        "transferOwnership",
+        "--help"
+      ],
+      "node_kind": "operation",
+      "operation_kind": "unknown",
+      "undo_support": {
+        "kind": "none"
       }
     },
     {
@@ -1968,6 +1990,7 @@
         "get",
         "list",
         "patch",
+        "search",
         "update",
         "attachments",
         "reactions"
@@ -2260,6 +2283,29 @@
         "chat",
         "spaces",
         "messages",
+        "search"
+      ],
+      "command": "gws chat spaces messages search",
+      "summary": "Searches for messages in Google Chat that the calling user has access to. Returns a list of messages matching the search criteria.",
+      "usage": "gws spaces messages search [OPTIONS]",
+      "help_args": [
+        "chat",
+        "spaces",
+        "messages",
+        "search",
+        "--help"
+      ],
+      "node_kind": "operation",
+      "operation_kind": "read",
+      "undo_support": {
+        "kind": "none"
+      }
+    },
+    {
+      "path": [
+        "chat",
+        "spaces",
+        "messages",
         "update"
       ],
       "command": "gws chat spaces messages update",
@@ -2431,9 +2477,153 @@
         "kind": "unknown"
       },
       "subcommands": [
+        "availability",
         "sections",
         "spaces"
       ]
+    },
+    {
+      "path": [
+        "chat",
+        "users",
+        "availability"
+      ],
+      "command": "gws chat users availability",
+      "summary": "Operations on the 'availability' resource",
+      "usage": "gws users availability [OPTIONS] <COMMAND>",
+      "help_args": [
+        "chat",
+        "users",
+        "availability",
+        "--help"
+      ],
+      "node_kind": "group",
+      "operation_kind": "unknown",
+      "undo_support": {
+        "kind": "unknown"
+      },
+      "subcommands": [
+        "get",
+        "markAsActive",
+        "markAsAway",
+        "markAsDoNotDisturb",
+        "patch"
+      ]
+    },
+    {
+      "path": [
+        "chat",
+        "users",
+        "availability",
+        "get"
+      ],
+      "command": "gws chat users availability get",
+      "summary": "Returns availability information for a human user in Google Chat. For example, this can be used to check if a user is online or away, or to retrieve their custom status message.",
+      "usage": "gws users availability get [OPTIONS]",
+      "help_args": [
+        "chat",
+        "users",
+        "availability",
+        "get",
+        "--help"
+      ],
+      "node_kind": "operation",
+      "operation_kind": "read",
+      "undo_support": {
+        "kind": "none"
+      }
+    },
+    {
+      "path": [
+        "chat",
+        "users",
+        "availability",
+        "markAsActive"
+      ],
+      "command": "gws chat users availability markAsActive",
+      "summary": "Marks user as `ACTIVE` in Google Chat. Sets the user's availability state to `ACTIVE`. The `ACTIVE` state lasts until the specified expiration, at which point the user's state becomes `AWAY`.",
+      "usage": "gws users availability markAsActive [OPTIONS]",
+      "help_args": [
+        "chat",
+        "users",
+        "availability",
+        "markAsActive",
+        "--help"
+      ],
+      "node_kind": "operation",
+      "operation_kind": "unknown",
+      "undo_support": {
+        "kind": "none"
+      }
+    },
+    {
+      "path": [
+        "chat",
+        "users",
+        "availability",
+        "markAsAway"
+      ],
+      "command": "gws chat users availability markAsAway",
+      "summary": "Marks user as `AWAY` in Google Chat. Sets the user's state to away and is not affected by the user's activity. This method only updates the authenticated user's availability.",
+      "usage": "gws users availability markAsAway [OPTIONS]",
+      "help_args": [
+        "chat",
+        "users",
+        "availability",
+        "markAsAway",
+        "--help"
+      ],
+      "node_kind": "operation",
+      "operation_kind": "unknown",
+      "undo_support": {
+        "kind": "none"
+      }
+    },
+    {
+      "path": [
+        "chat",
+        "users",
+        "availability",
+        "markAsDoNotDisturb"
+      ],
+      "command": "gws chat users availability markAsDoNotDisturb",
+      "summary": "Marks user as `DO_NOT_DISTURB` in Google Chat. Sets a user's availability state to `DO_NOT_DISTURB` until a specified expiration time.",
+      "usage": "gws users availability markAsDoNotDisturb [OPTIONS]",
+      "help_args": [
+        "chat",
+        "users",
+        "availability",
+        "markAsDoNotDisturb",
+        "--help"
+      ],
+      "node_kind": "operation",
+      "operation_kind": "unknown",
+      "undo_support": {
+        "kind": "none"
+      }
+    },
+    {
+      "path": [
+        "chat",
+        "users",
+        "availability",
+        "patch"
+      ],
+      "command": "gws chat users availability patch",
+      "summary": "Updates availability information for a human user. Only the `custom_status` field can be updated through this method. This method only updates the authenticated user's availability.",
+      "usage": "gws users availability patch [OPTIONS]",
+      "help_args": [
+        "chat",
+        "users",
+        "availability",
+        "patch",
+        "--help"
+      ],
+      "node_kind": "operation",
+      "operation_kind": "write",
+      "undo_support": {
+        "kind": "unknown"
+      }
     },
     {
       "path": [

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -4,16 +4,16 @@ Generated from the live `switchboard` tool registry, committed CLI inventories, 
 
 ## Snapshot
 
-- Tools: `761`
+- Tools: `768`
 - Curated: `15`
-- Raw inventory passthrough: `746`
+- Raw inventory passthrough: `753`
 - Planning-only: `4`
 - Undoable: `1`
 
 ## Providers
 
 - [github](providers/github.md) for `198` tools (`7` curated, `191` raw)
-- [google](providers/google.md) for `499` tools (`8` curated, `491` raw)
+- [google](providers/google.md) for `506` tools (`8` curated, `498` raw)
 - [mychart](providers/mychart.md) for `32` tools (`0` curated, `32` raw)
 - [schwab](providers/schwab.md) for `32` tools (`0` curated, `32` raw)
 

--- a/docs/reference/catalog.json
+++ b/docs/reference/catalog.json
@@ -1,8 +1,8 @@
 {
   "stats": {
-    "tool_count": 761,
+    "tool_count": 768,
     "curated_count": 15,
-    "raw_count": 746,
+    "raw_count": 753,
     "stable_count": 11,
     "planning_only_count": 4,
     "undoable_count": 1
@@ -20,9 +20,9 @@
     },
     {
       "provider": "google",
-      "tool_count": 499,
+      "tool_count": 506,
       "curated_count": 8,
-      "raw_count": 491,
+      "raw_count": 498,
       "stable_count": 6,
       "planning_only_count": 2,
       "undoable_count": 1,
@@ -8114,6 +8114,40 @@
       "doc_path": "reference/#tool=google.cli.calendar.calendars.patch"
     },
     {
+      "name": "google.cli.calendar.calendars.transferOwnership",
+      "provider": "google",
+      "kind": "write",
+      "backend": "cli",
+      "summary": "Run raw gws command gws calendar calendars transferOwnership",
+      "surface": "raw",
+      "aggregate_read_supported": false,
+      "execution_support": "executable",
+      "undo_support": "none",
+      "status": "raw",
+      "arguments": [
+        {
+          "name": "argv",
+          "transport": "passthrough_argv",
+          "value_kind": "string",
+          "required": false,
+          "repeated": true
+        }
+      ],
+      "available_namespaces": [],
+      "notes": [
+        "policy, auth isolation, and audit still apply",
+        "repeat --ns for aggregate reads, writes stay single-namespace",
+        "put switchboard flags before --, everything after -- is forwarded to the provider CLI unchanged",
+        "for scripted calls, --argv-json accepts one JSON array of argv tokens"
+      ],
+      "examples": [
+        "switchboard google.cli.calendar.calendars.transferOwnership --ns google.default --draft -- --format json ...",
+        "switchboard google.cli.calendar.calendars.transferOwnership --ns google.default --argv-json '[\"--format\",\"json\",...]' --apply --json",
+        "# fixed CLI path: calendar calendars transferOwnership"
+      ],
+      "doc_path": "reference/#tool=google.cli.calendar.calendars.transferOwnership"
+    },
+    {
       "name": "google.cli.calendar.calendars.update",
       "provider": "google",
       "kind": "write",
@@ -9678,6 +9712,40 @@
       "doc_path": "reference/#tool=google.cli.chat.spaces.messages.reactions.list"
     },
     {
+      "name": "google.cli.chat.spaces.messages.search",
+      "provider": "google",
+      "kind": "read",
+      "backend": "cli",
+      "summary": "Run raw gws command gws chat spaces messages search",
+      "surface": "raw",
+      "aggregate_read_supported": true,
+      "execution_support": "executable",
+      "undo_support": "none",
+      "status": "raw",
+      "arguments": [
+        {
+          "name": "argv",
+          "transport": "passthrough_argv",
+          "value_kind": "string",
+          "required": false,
+          "repeated": true
+        }
+      ],
+      "available_namespaces": [],
+      "notes": [
+        "policy, auth isolation, and audit still apply",
+        "repeat --ns for aggregate reads, writes stay single-namespace",
+        "put switchboard flags before --, everything after -- is forwarded to the provider CLI unchanged",
+        "for scripted calls, --argv-json accepts one JSON array of argv tokens"
+      ],
+      "examples": [
+        "switchboard google.cli.chat.spaces.messages.search --ns google.default --json -- --format json",
+        "switchboard google.cli.chat.spaces.messages.search --ns google.default --argv-json '[\"--format\",\"json\"]' --json",
+        "# fixed CLI path: chat spaces messages search"
+      ],
+      "doc_path": "reference/#tool=google.cli.chat.spaces.messages.search"
+    },
+    {
       "name": "google.cli.chat.spaces.messages.update",
       "provider": "google",
       "kind": "write",
@@ -9880,6 +9948,176 @@
         "# fixed CLI path: chat spaces spaceEvents list"
       ],
       "doc_path": "reference/#tool=google.cli.chat.spaces.spaceEvents.list"
+    },
+    {
+      "name": "google.cli.chat.users.availability.get",
+      "provider": "google",
+      "kind": "read",
+      "backend": "cli",
+      "summary": "Run raw gws command gws chat users availability get",
+      "surface": "raw",
+      "aggregate_read_supported": true,
+      "execution_support": "executable",
+      "undo_support": "none",
+      "status": "raw",
+      "arguments": [
+        {
+          "name": "argv",
+          "transport": "passthrough_argv",
+          "value_kind": "string",
+          "required": false,
+          "repeated": true
+        }
+      ],
+      "available_namespaces": [],
+      "notes": [
+        "policy, auth isolation, and audit still apply",
+        "repeat --ns for aggregate reads, writes stay single-namespace",
+        "put switchboard flags before --, everything after -- is forwarded to the provider CLI unchanged",
+        "for scripted calls, --argv-json accepts one JSON array of argv tokens"
+      ],
+      "examples": [
+        "switchboard google.cli.chat.users.availability.get --ns google.default --json -- --format json",
+        "switchboard google.cli.chat.users.availability.get --ns google.default --argv-json '[\"--format\",\"json\"]' --json",
+        "# fixed CLI path: chat users availability get"
+      ],
+      "doc_path": "reference/#tool=google.cli.chat.users.availability.get"
+    },
+    {
+      "name": "google.cli.chat.users.availability.markAsActive",
+      "provider": "google",
+      "kind": "write",
+      "backend": "cli",
+      "summary": "Run raw gws command gws chat users availability markAsActive",
+      "surface": "raw",
+      "aggregate_read_supported": false,
+      "execution_support": "executable",
+      "undo_support": "none",
+      "status": "raw",
+      "arguments": [
+        {
+          "name": "argv",
+          "transport": "passthrough_argv",
+          "value_kind": "string",
+          "required": false,
+          "repeated": true
+        }
+      ],
+      "available_namespaces": [],
+      "notes": [
+        "policy, auth isolation, and audit still apply",
+        "repeat --ns for aggregate reads, writes stay single-namespace",
+        "put switchboard flags before --, everything after -- is forwarded to the provider CLI unchanged",
+        "for scripted calls, --argv-json accepts one JSON array of argv tokens"
+      ],
+      "examples": [
+        "switchboard google.cli.chat.users.availability.markAsActive --ns google.default --draft -- --format json ...",
+        "switchboard google.cli.chat.users.availability.markAsActive --ns google.default --argv-json '[\"--format\",\"json\",...]' --apply --json",
+        "# fixed CLI path: chat users availability markAsActive"
+      ],
+      "doc_path": "reference/#tool=google.cli.chat.users.availability.markAsActive"
+    },
+    {
+      "name": "google.cli.chat.users.availability.markAsAway",
+      "provider": "google",
+      "kind": "write",
+      "backend": "cli",
+      "summary": "Run raw gws command gws chat users availability markAsAway",
+      "surface": "raw",
+      "aggregate_read_supported": false,
+      "execution_support": "executable",
+      "undo_support": "none",
+      "status": "raw",
+      "arguments": [
+        {
+          "name": "argv",
+          "transport": "passthrough_argv",
+          "value_kind": "string",
+          "required": false,
+          "repeated": true
+        }
+      ],
+      "available_namespaces": [],
+      "notes": [
+        "policy, auth isolation, and audit still apply",
+        "repeat --ns for aggregate reads, writes stay single-namespace",
+        "put switchboard flags before --, everything after -- is forwarded to the provider CLI unchanged",
+        "for scripted calls, --argv-json accepts one JSON array of argv tokens"
+      ],
+      "examples": [
+        "switchboard google.cli.chat.users.availability.markAsAway --ns google.default --draft -- --format json ...",
+        "switchboard google.cli.chat.users.availability.markAsAway --ns google.default --argv-json '[\"--format\",\"json\",...]' --apply --json",
+        "# fixed CLI path: chat users availability markAsAway"
+      ],
+      "doc_path": "reference/#tool=google.cli.chat.users.availability.markAsAway"
+    },
+    {
+      "name": "google.cli.chat.users.availability.markAsDoNotDisturb",
+      "provider": "google",
+      "kind": "write",
+      "backend": "cli",
+      "summary": "Run raw gws command gws chat users availability markAsDoNotDisturb",
+      "surface": "raw",
+      "aggregate_read_supported": false,
+      "execution_support": "executable",
+      "undo_support": "none",
+      "status": "raw",
+      "arguments": [
+        {
+          "name": "argv",
+          "transport": "passthrough_argv",
+          "value_kind": "string",
+          "required": false,
+          "repeated": true
+        }
+      ],
+      "available_namespaces": [],
+      "notes": [
+        "policy, auth isolation, and audit still apply",
+        "repeat --ns for aggregate reads, writes stay single-namespace",
+        "put switchboard flags before --, everything after -- is forwarded to the provider CLI unchanged",
+        "for scripted calls, --argv-json accepts one JSON array of argv tokens"
+      ],
+      "examples": [
+        "switchboard google.cli.chat.users.availability.markAsDoNotDisturb --ns google.default --draft -- --format json ...",
+        "switchboard google.cli.chat.users.availability.markAsDoNotDisturb --ns google.default --argv-json '[\"--format\",\"json\",...]' --apply --json",
+        "# fixed CLI path: chat users availability markAsDoNotDisturb"
+      ],
+      "doc_path": "reference/#tool=google.cli.chat.users.availability.markAsDoNotDisturb"
+    },
+    {
+      "name": "google.cli.chat.users.availability.patch",
+      "provider": "google",
+      "kind": "write",
+      "backend": "cli",
+      "summary": "Run raw gws command gws chat users availability patch",
+      "surface": "raw",
+      "aggregate_read_supported": false,
+      "execution_support": "executable",
+      "undo_support": "none",
+      "status": "raw",
+      "arguments": [
+        {
+          "name": "argv",
+          "transport": "passthrough_argv",
+          "value_kind": "string",
+          "required": false,
+          "repeated": true
+        }
+      ],
+      "available_namespaces": [],
+      "notes": [
+        "policy, auth isolation, and audit still apply",
+        "repeat --ns for aggregate reads, writes stay single-namespace",
+        "put switchboard flags before --, everything after -- is forwarded to the provider CLI unchanged",
+        "for scripted calls, --argv-json accepts one JSON array of argv tokens"
+      ],
+      "examples": [
+        "switchboard google.cli.chat.users.availability.patch --ns google.default --draft -- --format json ...",
+        "switchboard google.cli.chat.users.availability.patch --ns google.default --argv-json '[\"--format\",\"json\",...]' --apply --json",
+        "# fixed CLI path: chat users availability patch"
+      ],
+      "doc_path": "reference/#tool=google.cli.chat.users.availability.patch"
     },
     {
       "name": "google.cli.chat.users.sections.create",

--- a/docs/reference/providers/google.md
+++ b/docs/reference/providers/google.md
@@ -1,6 +1,6 @@
 # `google` Provider
 
-`google` exposes `499` total tools, `8` curated and `491` raw inventory passthrough.
+`google` exposes `506` total tools, `8` curated and `498` raw inventory passthrough.
 
 ## Curated tools
 
@@ -18,4 +18,4 @@
 - `google.cli.read`
 - `google.cli.write`
 
-`google` also ships `489` more raw command projections. The complete structured surface lives in [catalog.json](../catalog.json) and the deployed reference explorer.
+`google` also ships `496` more raw command projections. The complete structured surface lives in [catalog.json](../catalog.json) and the deployed reference explorer.

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -3,7 +3,7 @@
 | Provider | Stable curated | Planning-only curated | Raw passthrough | Undoable |
 | --- | ---: | ---: | ---: | ---: |
 | `github` | 5 | 2 | 191 | 0 |
-| `google` | 6 | 2 | 491 | 1 |
+| `google` | 6 | 2 | 498 | 1 |
 | `mychart` | 0 | 0 | 32 | 0 |
 | `schwab` | 0 | 0 | 32 | 0 |
 


### PR DESCRIPTION
## Summary

- regenerate the Google CLI inventory with the CI-pinned gws 0.22.5
- regenerate dependent reference docs and catalog snapshots
- restore the generated-artifact gates that failed on main

## Validation

- catalog check with CI-pinned gh 2.93.0 and gws 0.22.5
- generated docs check
- cargo fmt --check
- cargo clippy --all --all-features --benches --tests --examples
- cargo test --workspace --all-features
- cargo bench --workspace --all-features --no-run
- git diff --check